### PR TITLE
move hardcoded instance label as adjustable variable

### DIFF
--- a/oxidized.conf.sample
+++ b/oxidized.conf.sample
@@ -2,3 +2,4 @@
 url = https://oxidized.domain.net
 addr = 0.0.0.0
 port = 5002
+label = instance

--- a/oxidized_exporter
+++ b/oxidized_exporter
@@ -17,7 +17,7 @@ class OxidizedCollector(object):
         for node in response:
             status = 1 if node["status"] == "success" else 0
             metric.add_sample(
-                "oxidized_status", value=status, labels={"instance": node["name"]}
+                "oxidized_status", value=status, labels={config["default"]["label"]: node["name"]}
             )
 
         yield metric


### PR DESCRIPTION
This allows the user to modify the used prometheus label name as needed. e.g. "hostname" instead of "instance/exported_instance". Keeping the default _instance_ in the sample config.